### PR TITLE
Try adding an opt-in package+deployment for busybox

### DIFF
--- a/deployments/busybox-alpine-flix.deploy.yml
+++ b/deployments/busybox-alpine-flix.deploy.yml
@@ -1,0 +1,4 @@
+package: /deployments/busybox
+features:
+  - alpine-flix
+disabled: true

--- a/deployments/busybox/forklift-package.yml
+++ b/deployments/busybox/forklift-package.yml
@@ -1,0 +1,21 @@
+package:
+  description: A systemd sysext providing busybox from alpine
+  # Note: maintainers describes the maintainer(s) of the Forklift package, not the upstream software
+  maintainers:
+    - name: Ethan Li
+      email: lietk12@gmail.com
+  license: GPL-2.0-only
+  sources:
+    - https://www.busybox.net/
+
+features:
+  alpine-flix:
+    description:
+      busybox tools provided through Alpine Linux and sandboxed with flix
+    provides:
+      file-exports:
+        - description: systemd sysext
+          source-type: oci-image
+          url: ghcr.io/ethanjli/sysext-dir-busybox-alpine-flix:sha-05a49de
+          source: /
+          target: extensions/busybox


### PR DESCRIPTION
This PR integrates the changes from https://github.com/ethanjli/ublue-forklift-sysext-demo/pull/10 into this pallet by adding a package deployment (disabled by default) to provide busybox from https://github.com/ethanjli/ublue-forklift-sysext-demo/pkgs/container/sysext-dir-busybox-alpine-flix.